### PR TITLE
Add addCountryHeader option (optionally sets X-IPCountry Request Header)

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -178,6 +178,7 @@ my-GeoBlock:
             allowUnknownCountries: false
             unknownCountryApiResponse: "nil"
             blackListMode: false
+            addCountryHeader: false
             countries:
                 - AF # Afghanistan
                 - AL # Albania
@@ -490,3 +491,7 @@ allowedIPAddresses:
   - 203.0.113.0/24      # IPv4 range in CIDR format  
   - 2001:db8:1234:/48   # IPv6 range in CIDR format
 ```
+
+### Add Header to request with Country Code: `addCountryHeader`
+
+If set to `true`, adds the X-IPCountry header to the HTTP request header. The header contains the two letter country code returned by cache or API request.


### PR DESCRIPTION
This adds a new configuration option, which when enabled adds an additional Request header with the country code returned from cache/API.

The configuration option (addCountryHeader) is disabled by default, and the header is X-IPCountry (borrowed from Cloudflare's CF-IPCountry).

It's useful for if you want to allow backend applications to make more granular decisions about how they handle traffic from particular countries, rather than an all-or-nothing configuration in Traefik (or complicating Traefik configuration by having multiple routers and middleware instances).

resolves #10 