### PR TITLE
Potential fix for code scanning alert no. 12: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -1,6 +1,9 @@
 name: Go Matrix
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   cross:
     name: Go


### PR DESCRIPTION
Potential fix for [https://github.com/PascalMinder/geoblock/security/code-scanning/12](https://github.com/PascalMinder/geoblock/security/code-scanning/12)

Add an explicit top-level `permissions` block in `.github/workflows/go-cross.yml` so all jobs inherit least-privilege access.  
Best fix without changing functionality: set:

- `contents: read`

This is sufficient for `actions/checkout` and test execution, and keeps token scope minimal.  
Change location: directly under the `on:` section (before `jobs:`), so it applies to the `cross` job and any future jobs unless overridden.  
No imports, methods, or dependencies are needed (YAML config-only change).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
