### PR TITLE
Share one IP cache per middleware across its instances

### DIFF
--- a/cachePersistence.go
+++ b/cachePersistence.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -196,6 +197,39 @@ func (p *CachePersist) flushIfDirty() {
 
 	atomic.StoreUint32(&p.cacheDirty, 0)
 	p.lastFlush.Store(time.Now().UnixNano())
+}
+
+type sharedCacheEntry struct {
+	cache   *lru.LRUCache
+	persist *CachePersist
+}
+
+var (
+	sharedCachesMu sync.Mutex
+	sharedCaches   = map[string]*sharedCacheEntry{}
+)
+
+// GetOrInitCache shares one cache and persistence worker per middleware name,
+// created once on first use. Traefik builds the middleware several times (per
+// router and per config reload); sharing means an IP is looked up once, and a
+// single worker owns the persisted file instead of several racing to write it.
+// The worker uses a detached context to outlive any single instance (e.g. a
+// reload), which would otherwise leave the shared cache without a worker.
+func GetOrInitCache(opt Options) (*lru.LRUCache, *CachePersist, error) {
+	sharedCachesMu.Lock()
+	defer sharedCachesMu.Unlock()
+
+	if sc, ok := sharedCaches[opt.Name]; ok {
+		return sc.cache, sc.persist, nil
+	}
+
+	cache, persist, err := InitializeCache(context.Background(), opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sharedCaches[opt.Name] = &sharedCacheEntry{cache: cache, persist: persist}
+	return cache, persist, nil
 }
 
 func InitializeCache(ctx context.Context, opt Options) (*lru.LRUCache, *CachePersist, error) {

--- a/geoblock.go
+++ b/geoblock.go
@@ -163,7 +163,8 @@ func New(ctx context.Context, next http.Handler, config *Config, name string) (h
 		SilentStartUp:   config.SilentStartUp,
 		Name:            name,
 	}
-	cache, ipDB, err := InitializeCache(ctx, cacheOptions)
+	// Share one cache + persistence worker per middleware (see GetOrInitCache).
+	cache, ipDB, err := GetOrInitCache(cacheOptions)
 	if err != nil {
 		infoLogger.Fatal(err)
 	}

--- a/geoblock_test.go
+++ b/geoblock_test.go
@@ -40,7 +40,7 @@ func TestEmptyApi(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	_, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	_, err := geoblock.New(ctx, next, cfg, t.Name())
 
 	// expect error
 	if err == nil {
@@ -56,7 +56,7 @@ func TestMissingIpInApi(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	_, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	_, err := geoblock.New(ctx, next, cfg, t.Name())
 
 	// expect error
 	if err == nil {
@@ -70,7 +70,7 @@ func TestEmptyAllowedCountryList(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	_, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	_, err := geoblock.New(ctx, next, cfg, t.Name())
 
 	// expect error
 	if err == nil {
@@ -85,7 +85,7 @@ func TestEmptyDeniedRequestStatusCode(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	_, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	_, err := geoblock.New(ctx, next, cfg, t.Name())
 
 	if err != nil {
 		t.Fatal("no error expected for empty denied request status code")
@@ -100,7 +100,7 @@ func TestInvalidDeniedRequestStatusCode(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	_, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	_, err := geoblock.New(ctx, next, cfg, t.Name())
 
 	// expect error
 	if err == nil {
@@ -115,7 +115,7 @@ func TestAllowedCountry(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("Allowed request")) })
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestMultipleAllowedCountry(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -180,7 +180,7 @@ func TestMultipleForwardedForIP(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("Allowed request")) })
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -219,7 +219,7 @@ func TestMultipleForwardedForIPwithSpaces(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("Allowed request")) })
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -281,7 +281,7 @@ func TestMultipleIpAddresses(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,7 +312,7 @@ func TestIpAddressesWithSpaces(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -343,7 +343,7 @@ func TestMultipleIpAddressesReverse(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -375,7 +375,7 @@ func TestMultipleIpAddressesProxy(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -407,7 +407,7 @@ func TestMultipleIpAddressesProxyReverse(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -436,7 +436,7 @@ func TestAllowedUnknownCountry(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -462,7 +462,7 @@ func TestDenyUnknownCountry(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -488,7 +488,7 @@ func TestAllowedCountryCacheLookUp(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -516,7 +516,7 @@ func TestDeniedCountry(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write([]byte("Allowed request")) })
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -555,7 +555,7 @@ func TestDeniedCountryWithRedirect(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -584,7 +584,7 @@ func TestCustomDeniedRequestStatusCode(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -611,7 +611,7 @@ func TestAllowBlacklistMode(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -638,7 +638,7 @@ func TestDenyBlacklistMode(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -665,7 +665,7 @@ func TestAllowLocalIP(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -691,7 +691,7 @@ func TestPrivateIPRange(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -717,7 +717,7 @@ func TestInvalidIp(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -747,7 +747,7 @@ func TestInvalidApiResponse(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -781,7 +781,7 @@ func TestApiResponseTimeoutAllowed(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -815,7 +815,7 @@ func TestApiResponseTimeoutNotAllowed(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -845,7 +845,7 @@ func TestExplicitlyAllowedIP(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -879,7 +879,7 @@ func TestExplicitlyAllowedIPWithIPCountryHeader(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -907,7 +907,7 @@ func TestExplicitlyAllowedIPNoMatch(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -935,7 +935,7 @@ func TestExplicitlyAllowedIPRangeIPV6(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -963,7 +963,7 @@ func TestExplicitlyAllowedIPRangeIPV6NoMatch(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -991,7 +991,7 @@ func TestExplicitlyAllowedIPRangeIPV4(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1019,7 +1019,7 @@ func TestExplicitlyAllowedIPRangeIPV4NoMatch(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1046,7 +1046,7 @@ func TestCountryHeader(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1074,7 +1074,7 @@ func TestIpGeolocationHttpField(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1119,7 +1119,7 @@ func TestIpGeolocationHttpFieldContentInvalid(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1161,7 +1161,7 @@ func TestCustomLogFile(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1203,7 +1203,7 @@ func TestLogDeniedDueToHeaderError_FirstCall(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1263,7 +1263,7 @@ func TestTimeoutOnApiResponse_DenyWhenIgnoreTimeoutFalse(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1306,7 +1306,7 @@ func TestTimeoutOnApiResponse_AllowWhenIgnoreTimeoutTrue(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1335,7 +1335,7 @@ func TestErrorOnApiResponse_AllowWhenIgnoreAPIFailuresTrue(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1364,7 +1364,7 @@ func TestErrorOnApiResponse_AllowWhenIgnoreAPIFailuresFalse(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1441,7 +1441,7 @@ func TestExcludedPathPattern(t *testing.T) {
 		_, _ = w.Write([]byte(allowedRequest))
 	})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1482,7 +1482,7 @@ func TestExcludedDomainPattern(t *testing.T) {
 		_, _ = w.Write([]byte(allowedRequest))
 	})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1523,7 +1523,7 @@ func TestExcludedDomainAndPathPattern(t *testing.T) {
 		_, _ = w.Write([]byte(allowedRequest))
 	})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1550,7 +1550,7 @@ func TestExcludedDomainAndPathPatternNoMatch(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1584,7 +1584,7 @@ func TestExcludedPathPatternMultiple(t *testing.T) {
 		_, _ = w.Write([]byte(allowedRequest))
 	})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1615,7 +1615,7 @@ func TestExcludedPathPatternNoMatch(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	handler, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	handler, err := geoblock.New(ctx, next, cfg, t.Name())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1642,7 +1642,7 @@ func TestInvalidExcludedPathPattern(t *testing.T) {
 	ctx := context.Background()
 	next := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {})
 
-	_, err := geoblock.New(ctx, next, cfg, "GeoBlock")
+	_, err := geoblock.New(ctx, next, cfg, t.Name())
 
 	if err == nil {
 		t.Fatal("expected error for invalid regex pattern")
@@ -1719,6 +1719,40 @@ func TestInitializeCache_PersistsAcrossRestart(t *testing.T) {
 		}
 
 		cancel()
+	}
+}
+
+func TestGetOrInitCache_SharedByName(t *testing.T) {
+	t.Parallel()
+
+	opt := geoblock.Options{Name: t.Name(), CacheSize: 32}
+
+	first, _, err := geoblock.GetOrInitCache(opt)
+	if err != nil {
+		t.Fatalf("GetOrInitCache(first) failed: %v", err)
+	}
+	second, _, err := geoblock.GetOrInitCache(opt)
+	if err != nil {
+		t.Fatalf("GetOrInitCache(second) failed: %v", err)
+	}
+
+	// The same name must hand back the same cache, so a write through one handle is
+	// visible through the other.
+	if first != second {
+		t.Fatal("expected the same cache instance for the same name")
+	}
+	first.Add("1.2.3.4", true)
+	if _, ok := second.Get("1.2.3.4"); !ok {
+		t.Fatal("expected entry written via first handle to be visible via second")
+	}
+
+	// A different name must get an independent cache.
+	other, _, err := geoblock.GetOrInitCache(geoblock.Options{Name: t.Name() + "-other", CacheSize: 32})
+	if err != nil {
+		t.Fatalf("GetOrInitCache(other) failed: %v", err)
+	}
+	if other == first {
+		t.Fatal("expected a different cache instance for a different name")
 	}
 }
 


### PR DESCRIPTION
## Problem

Traefik builds a middleware multiple times: once for each router that references it, and again on every configuration reload. Each build calls the plugin's `New()`, producing an independent `*GeoBlock` with its own in-memory LRU cache and, when `ipDatabaseCachePath` is set, its own persistence worker.

This has two consequences:

1. **Redundant geolocation lookups.**
   The same client IP is resolved separately by each instance, multiplying calls to the rate-limited geolocation API and reducing the cache hit rate.

2. **Racing writers on the persisted cache.**
   When persistence is enabled, each instance runs its own worker that periodically writes to the same file. Writes are atomic, using a temporary file followed by a rename, so the file is never corrupted. However, the result is still last-writer-wins: entries cached only by other instances are dropped, and on the next restart the warm-load reads an arbitrary partial snapshot.

## Fix

Resolve the cache and persistence worker through a small process-wide registry keyed by middleware name: `GetOrInitCache`.

All instances of the same middleware now share one cache and one writer:

* an IP is looked up once and reused across instances;
* exactly one worker owns the persisted file.

The shared worker runs under a detached context, so it survives the teardown of any single instance, such as during a configuration reload, instead of stopping with the first instance that goes away.

Single-instance behavior is unchanged. This only deduplicates what were previously independent copies.

## Tests

* Added `TestGetOrInitCache_SharedByName`.

  * Same name → same cache, with writes visible across handles.
  * Different name → independent cache.

* Updated existing tests to pass a unique middleware name via `t.Name()`.

Previously, the tests all used the literal `"GeoBlock"`. With a shared-by-name cache, that would correctly make logically distinct test middlewares share state. Using `t.Name()` mirrors production behavior, where distinct middlewares always have distinct names.

## Notes

Sharing is keyed by middleware name. Two distinct middlewares pointing at the same `ipDatabaseCachePath`, which is an unusual configuration, keep separate caches as before.
